### PR TITLE
Added GridGap functionality to grid component

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Here is listed the basic API of both KtdGridComponent and KtdGridItemComponent. 
 /** Layout of the grid. Array of all the grid items with its 'id' and position on the grid. */
 @Input() layout: KtdGridLayout;
 
+/** Grid gap in css pixels */
+@Input() gap: number = 0;
+
 /**
  * Parent element that contains the scroll. If an string is provided it would search that element by id on the dom.
  * If no data provided or null autoscroll is not performed.
@@ -159,7 +162,7 @@ Here is listed the basic API of both KtdGridComponent and KtdGridItemComponent. 
 - [x] Add dragStartThreshold option to grid items.
 - [x] Auto Scroll vertical/horizontal if container is scrollable when dragging a grid item. ([commit](https://github.com/katoid/angular-grid-layout/commit/d137d0e3f40cafdb5fdfd7b2bce4286670200c5d)).
 - [x] Grid support for minWidth/maxWidth and minHeight/maxHeight on grid items.
-- [ ] Add grid gap feature.
+- [x] Add grid gap feature.
 - [ ] rowHeight to support also 'fit' as value instead of only CSS pixels ([issue](https://github.com/katoid/angular-grid-layout/issues/1)).
 - [ ] Grid support for static grid items.
 - [ ] Customizable drag placeholder.

--- a/projects/angular-grid-layout/src/lib/grid.definitions.ts
+++ b/projects/angular-grid-layout/src/lib/grid.definitions.ts
@@ -21,6 +21,7 @@ export interface KtdGridCfg {
     rowHeight: number; // row height in pixels
     layout: KtdGridLayoutItem[];
     preventCollision: boolean;
+    gap: number;
 }
 
 export type KtdGridLayout = KtdGridLayoutItem[];

--- a/projects/demo-app/src/app/playground/playground.component.html
+++ b/projects/demo-app/src/app/playground/playground.component.html
@@ -24,6 +24,10 @@
             <mat-label>Drag Threshold</mat-label>
             <input matInput type="number" [value]="dragStartThreshold + ''" (input)="onDragStartThresholdChange($event)">
         </mat-form-field>
+        <mat-form-field>
+            <mat-label>Gap</mat-label>
+            <input matInput type="number" [value]="gap" (input)="onGapChange($event)">
+        </mat-form-field>
         <mat-form-field color="accent">
             <mat-label>Transition type</mat-label>
             <mat-select [value]="currentTransition" (selectionChange)="onTransitionChange($event)">
@@ -73,6 +77,7 @@
                   [compactType]="compactType"
                   [preventCollision]="preventCollision"
                   [scrollableParent]="autoScroll ? document : null"
+                  [gap]="gap"
                   scrollSpeed="4"
                   (dragStarted)="onDragStarted($event)"
                   (resizeStarted)="onResizeStarted($event)"

--- a/projects/demo-app/src/app/playground/playground.component.ts
+++ b/projects/demo-app/src/app/playground/playground.component.ts
@@ -50,6 +50,7 @@ export class KtdPlaygroundComponent implements OnInit, OnDestroy {
     currentTransition: string = this.transitions[0].value;
 
     dragStartThreshold = 0;
+    gap = 0;
     autoScroll = true;
     disableDrag = false;
     disableResize = false;
@@ -145,6 +146,10 @@ export class KtdPlaygroundComponent implements OnInit, OnDestroy {
 
     onDragStartThresholdChange(event: Event) {
         this.dragStartThreshold = coerceNumberProperty((event.target as HTMLInputElement).value);
+    }
+
+    onGapChange(event: Event) {
+      this.gap = coerceNumberProperty((event.target as HTMLInputElement).value);
     }
 
     generateLayout() {


### PR DESCRIPTION
Feature/Merge request for Grid Gap functionality described in the TODO features of the project.

I notice their has been a workaround listed in https://github.com/katoid/angular-grid-layout/discussions/43, but wanted to make a formal issue to potentially support this feature.

Change list includes the addition of a gridGap input to the grid component, logic for calculating the grid items top, left, width, and height properties accounting for this new gridGap property, and similar logic for calculating the height of the grid. I also added an input to the playground demo so this can be seen visually.

Feel free to build off this and discuss any potential issues/changes that could be beneficial here