### PR TITLE
Min property and scroll bug

### DIFF
--- a/projects/angular-grid-layout/src/lib/grid.component.ts
+++ b/projects/angular-grid-layout/src/lib/grid.component.ts
@@ -48,15 +48,15 @@ function layoutToRenderItems(config: KtdGridCfg, width: number, height: number):
             id: item.id,
             top: item.y === 0 ? 0 : item.y * rowHeight,
             left: item.x * (width / cols),
-            width: item.w * (width / cols),
-            height: item.h * rowHeight
+            width: Math.max(item.w, item.minW ?? 0) * (width / cols),
+            height: Math.max(item.h, item.minH ?? 0) * rowHeight
         };
     }
     return renderItems;
 }
 
 function getGridHeight(layout: KtdGridLayout, rowHeight: number): number {
-    return layout.reduce((acc, cur) => Math.max(acc, (cur.y + cur.h) * rowHeight), 0);
+    return layout.reduce((acc, cur) => Math.max(acc, (cur.y + Math.max(cur.h, cur.minH ?? 0)) * rowHeight), 0);
 }
 
 // eslint-disable-next-line @katoid/prefix-exported-code

--- a/projects/angular-grid-layout/src/lib/grid.component.ts
+++ b/projects/angular-grid-layout/src/lib/grid.component.ts
@@ -254,6 +254,7 @@ export class KtdGridComponent implements OnChanges, AfterContentInit, AfterConte
 
     ngAfterContentInit() {
         this.initSubscriptions();
+        this.calculateRenderData();
     }
 
     ngAfterContentChecked() {


### PR DESCRIPTION
Changes for issues described in https://github.com/katoid/angular-grid-layout/issues/63

Change list includes doing width and height calculations off the max between the w and minW properties and the h and minH properties. Also triggering the calculateRenderData method after the content fully inits because the width of the parent was being consumed incorrectly in the ngOnInit method causing items to overflow outside parents bounds causing scroll.