### PR TITLE
Check null for subscriptions in ngOnDestroy

### DIFF
--- a/projects/angular-grid-layout/src/lib/grid.component.ts
+++ b/projects/angular-grid-layout/src/lib/grid.component.ts
@@ -325,7 +325,7 @@ export class KtdGridComponent implements OnChanges, AfterContentInit, AfterConte
     }
 
     ngOnDestroy() {
-        this.subscriptions.forEach(sub => sub.unsubscribe());
+        this.subscriptions?.forEach(sub => sub.unsubscribe());
     }
 
     compactLayout() {


### PR DESCRIPTION
In a scenario I got below error:
core.mjs:6397 ERROR TypeError: Cannot read properties of undefined (reading 'forEach')
    at KtdGridComponent.ngOnDestroy (katoid-angular-grid-layout.mjs:1612:28)