### PR TITLE
fix(grid-component): improve end of drag events of the grid elements

### DIFF
--- a/projects/angular-grid-layout/src/lib/grid.component.scss
+++ b/projects/angular-grid-layout/src/lib/grid.component.scss
@@ -41,7 +41,7 @@ ktd-grid {
     }
 
     ktd-grid-item {
-        &.ktd-grid-item-dragging {
+        &.ktd-grid-item-dragging, &.ktd-grid-item-animating {
             z-index: 1000;
         }
 

--- a/projects/angular-grid-layout/src/lib/utils/transition-duration.ts
+++ b/projects/angular-grid-layout/src/lib/utils/transition-duration.ts
@@ -1,0 +1,40 @@
+/**
+ * Transition duration utilities.
+ * This file is taken from Angular Material repository.
+ */
+
+/* eslint-disable @katoid/prefix-exported-code */
+
+/** Parses a CSS time value to milliseconds. */
+function parseCssTimeUnitsToMs(value: string): number {
+  // Some browsers will return it in seconds, whereas others will return milliseconds.
+  const multiplier = value.toLowerCase().indexOf('ms') > -1 ? 1 : 1000;
+  return parseFloat(value) * multiplier;
+}
+
+/** Gets the transform transition duration, including the delay, of an element in milliseconds. */
+export function getTransformTransitionDurationInMs(element: HTMLElement): number {
+  const computedStyle = getComputedStyle(element);
+  const transitionedProperties = parseCssPropertyValue(computedStyle, 'transition-property');
+  const property = transitionedProperties.find(prop => prop === 'transform' || prop === 'all');
+
+  // If there's no transition for `all` or `transform`, we shouldn't do anything.
+  if (!property) {
+    return 0;
+  }
+
+  // Get the index of the property that we're interested in and match
+  // it up to the same index in `transition-delay` and `transition-duration`.
+  const propertyIndex = transitionedProperties.indexOf(property);
+  const rawDurations = parseCssPropertyValue(computedStyle, 'transition-duration');
+  const rawDelays = parseCssPropertyValue(computedStyle, 'transition-delay');
+
+  return parseCssTimeUnitsToMs(rawDurations[propertyIndex]) +
+         parseCssTimeUnitsToMs(rawDelays[propertyIndex]);
+}
+
+/** Parses out multiple values from a computed style into an array. */
+function parseCssPropertyValue(computedStyle: CSSStyleDeclaration, name: string): string[] {
+  const value = computedStyle.getPropertyValue(name);
+  return value.split(',').map(part => part.trim());
+}


### PR DESCRIPTION
Improve end of drag events of the grid elements, basically animate over other elements
fixes #6 

also related to #5 

As mentioned in those issues, I followed the angular components' approach and adjusted it. It should be leak-friendly and ecologically sustainable :-)