### PR TITLE
fix: prevent browser drag event in custom handles

### DIFF
--- a/projects/angular-grid-layout/src/lib/utils/pointer.utils.ts
+++ b/projects/angular-grid-layout/src/lib/utils/pointer.utils.ts
@@ -84,7 +84,7 @@ function ktdMouseOrTouchDown(element, touchNumber = 1): Observable<MouseEvent | 
  * @param element, html element where to  listen the events.
  * @param touchNumber number of the touch to track the event, default to the first one.
  */
-function ktdMouserOrTouchMove(element: HTMLElement, touchNumber = 1): Observable<MouseEvent | TouchEvent> {
+function ktdMouseOrTouchMove(element: HTMLElement, touchNumber = 1): Observable<MouseEvent | TouchEvent> {
     return iif(
         () => ktdIsMobileOrTablet(),
         fromEvent<TouchEvent>(element, 'touchmove', activeEventListenerOptions as AddEventListenerOptions).pipe(
@@ -127,8 +127,8 @@ export function ktdPointerDown(element): Observable<MouseEvent | TouchEvent | Po
     if (!ktdSupportsPointerEvents()) {
         return ktdMouseOrTouchDown(element);
     }
-
-    return fromEvent<PointerEvent>(element, 'pointerdown', passiveEventListenerOptions as AddEventListenerOptions).pipe(
+    
+    return fromEvent<PointerEvent>(element, 'pointerdown', activeEventListenerOptions as AddEventListenerOptions).pipe(
         filter((pointerEvent) => pointerEvent.isPrimary)
     )
 }
@@ -139,7 +139,7 @@ export function ktdPointerDown(element): Observable<MouseEvent | TouchEvent | Po
  */
 export function ktdPointerMove(element): Observable<MouseEvent | TouchEvent | PointerEvent> {
     if (!ktdSupportsPointerEvents()) {
-        return ktdMouserOrTouchMove(element);
+        return ktdMouseOrTouchMove(element);
     }
     return fromEvent<PointerEvent>(element, 'pointermove', activeEventListenerOptions as AddEventListenerOptions).pipe(
         filter((pointerEvent) => pointerEvent.isPrimary),

--- a/projects/angular-grid-layout/src/lib/utils/pointer.utils.ts
+++ b/projects/angular-grid-layout/src/lib/utils/pointer.utils.ts
@@ -50,6 +50,11 @@ export function ktdPointerClient(event: MouseEvent | TouchEvent): { clientX: num
     };
 }
 
+export function ktdIsMouseEventOrMousePointerEvent(event: MouseEvent | TouchEvent | PointerEvent): boolean {
+    return event.type === 'mousedown'
+        || (event.type === 'pointerdown' && (event as PointerEvent).pointerType === 'mouse');
+}
+
 /** Returns true if browser supports pointer events */
 export function ktdSupportsPointerEvents(): boolean {
     return !!window.PointerEvent;
@@ -127,7 +132,7 @@ export function ktdPointerDown(element): Observable<MouseEvent | TouchEvent | Po
     if (!ktdSupportsPointerEvents()) {
         return ktdMouseOrTouchDown(element);
     }
-    
+
     return fromEvent<PointerEvent>(element, 'pointerdown', activeEventListenerOptions as AddEventListenerOptions).pipe(
         filter((pointerEvent) => pointerEvent.isPrimary)
     )

--- a/projects/demo-app/src/app/real-life-example/table-sorting/table-sorting.component.scss
+++ b/projects/demo-app/src/app/real-life-example/table-sorting/table-sorting.component.scss
@@ -3,6 +3,7 @@
     width: 100%;
     height: 100%;
     overflow-y: auto;
+    touch-action: none; // This is needed to make drag and drop on touch devices possible without interfering with the inner scroll.
 }
 
 table {


### PR DESCRIPTION
Prevent dragStart event on parent element to avoid fail if user drags it away quickly