### PR TITLE
feat: improve no compact mode without collision prevent

### DIFF
--- a/projects/angular-grid-layout/src/lib/grid.component.ts
+++ b/projects/angular-grid-layout/src/lib/grid.component.ts
@@ -8,7 +8,7 @@ import { KtdGridItemComponent } from './grid-item/grid-item.component';
 import { combineLatest, empty, merge, NEVER, Observable, Observer, of, Subscription } from 'rxjs';
 import { exhaustMap, map, startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { ktdGetGridItemRowHeight, ktdGridItemDragging, ktdGridItemLayoutItemAreEqual, ktdGridItemResizing } from './utils/grid.utils';
-import { compact } from './utils/react-grid-layout.utils';
+import { cloneLayoutItem, compact } from './utils/react-grid-layout.utils';
 import {
     GRID_ITEM_GET_RENDER_DATA_TOKEN, KtdGridBackgroundCfg, KtdGridCfg, KtdGridCompactType, KtdGridItemRenderData, KtdGridLayout, KtdGridLayoutItem
 } from './grid.definitions';
@@ -541,9 +541,11 @@ export class KtdGridComponent implements OnChanges, AfterContentInit, AfterConte
                          * Set the new layout to be the layout in which the calcNewStateFunc would be executed.
                          * NOTE: using the mutated layout is the way to go by 'react-grid-layout' utils. If we don't use the previous layout,
                          * some utilities from 'react-grid-layout' would not work as expected.
+                         *
+                         * In non-compact mode it is best to use copy of original layout, to prevent items from spreading on the grid
                          */
-                        const currentLayout: KtdGridLayout = newLayout || this.layout;
-
+                        const isCompactLayout = (['horizontal', 'vertical'] as KtdGridCompactType[]).includes(this.compactType)
+                        const currentLayout: KtdGridLayout = isCompactLayout ? (newLayout || this.layout) : this.layout.map((l) => cloneLayoutItem(l));
                         // Get the correct newStateFunc depending on if we are dragging or resizing
                         const calcNewStateFunc = type === 'drag' ? ktdGridItemDragging : ktdGridItemResizing;
 

--- a/projects/angular-grid-layout/src/lib/utils/grid.utils.ts
+++ b/projects/angular-grid-layout/src/lib/utils/grid.utils.ts
@@ -225,9 +225,20 @@ export function ktdGridItemResizing(gridItem: KtdGridItemComponent, config: KtdG
 
     }
 
-    const newLayoutItems: LayoutItem[] = config.layout.map((item) => {
-        return item.id === gridItemId ? layoutItem : item;
-    });
+    const layoutItems: LayoutItem[] = config.layout;
+    const resizedLayoutItem: LayoutItem = layoutItems.find(item => item.id === gridItemId)!;
+    let newLayoutItems: LayoutItem[] = moveElement(
+        layoutItems,
+        resizedLayoutItem,
+        undefined,
+        undefined,
+        true,
+        config.preventCollision,
+        compactionType,
+        config.cols,
+        layoutItem.w,
+        layoutItem.h,
+    );
 
     return {
         layout: compact(newLayoutItems, compactionType, config.cols),


### PR DESCRIPTION
I have been happily using grid with compact mode 'none' and 'prevent collision' enabled for the last 3 years, until my PO decided he want to enable collisions. As you might know it isn't working grate in that combination (items spread across the grid and single mis-drag can destroy whole layout):


https://github.com/user-attachments/assets/f8ff35cd-dc9e-4173-957f-74f30bfb8708


I implemented feature,that should change behaviour in compact mode 'none' without 'prevent collision', It basically restores original layout before resolving collisions, that way items are returning to their places if not colliding with dragged item:


https://github.com/user-attachments/assets/6463b36f-14af-4470-9ea5-734c0b1f761a


I also made resizing items more deterministic, by extending moveElement function into more like moveAndResizeElement.

@llorenspujol please have a look at it, I'm open to any questions and feedback.