### PR TITLE
fix(grid-item): touch-action should be set to auto when not draggable

### DIFF
--- a/projects/angular-grid-layout/src/lib/grid-item/grid-item.component.scss
+++ b/projects/angular-grid-layout/src/lib/grid-item/grid-item.component.scss
@@ -4,7 +4,6 @@
     position: absolute;
     z-index: 1;
     overflow: hidden;
-    touch-action: none;
 
     div {
         position: absolute;

--- a/projects/angular-grid-layout/src/lib/grid-item/grid-item.component.ts
+++ b/projects/angular-grid-layout/src/lib/grid-item/grid-item.component.ts
@@ -1,5 +1,5 @@
 import {
-    AfterContentInit, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, ElementRef, Inject, Input, NgZone, OnDestroy, OnInit,
+    AfterContentInit, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, ElementRef, HostBinding, Inject, Input, NgZone, OnDestroy, OnInit,
     QueryList, Renderer2, ViewChild
 } from '@angular/core';
 import { BehaviorSubject, NEVER, Observable, Subject, Subscription, iif, merge } from 'rxjs';
@@ -38,6 +38,11 @@ export class KtdGridItemComponent implements OnInit, OnDestroy, AfterContentInit
 
     /** CSS transition style. Note that for more performance is preferable only make transition on transform property. */
     @Input() transition: string = 'transform 500ms ease, width 500ms ease, height 500ms ease';
+
+    /** Dynamically apply `touch-action` to the host element based on draggable */
+    @HostBinding('style.touch-action') get touchAction(): string {
+        return this._draggable ? 'none' : 'auto';
+    }
 
     dragStart$: Observable<MouseEvent | TouchEvent>;
     resizeStart$: Observable<MouseEvent | TouchEvent>;


### PR DESCRIPTION
## Issue
Identified that `ktd-grid-item` was configured with `touch-action: none`, preventing default touch behaviors like swipe-to-scroll on mobile devices. This created a poor user experience as users couldn't scroll through grid content on touch devices.

## Solution
Modified the implementation to make `touch-action` variable based on the draggable state:
- When a grid-item becomes draggable: `touch-action: none` (prevents browser interference with drag operations)
- When an item is not draggable: `touch-action: auto` (allows normal touch scrolling)

This change maintains the desired drag functionality while restoring expected touch behavior when items aren't being actively manipulated.

Tested on various mobile devices to confirm proper scrolling functionality is restored. Let me know if you think this is a fitting solution or has some unintended effects.